### PR TITLE
autocompletion on page dwell

### DIFF
--- a/samples/login.html
+++ b/samples/login.html
@@ -6,12 +6,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
 
-    <script>
-        window.autotuneConfig = {
-            appKey: "0831cd5d-5c9c-489d-8fe6-f674bd09ec0e",
-            outcomes: {}
-        };
-    </script>
+    <script src="//s3.us-east-2.amazonaws.com/js.autotune.xyz/0831cd5d-5c9c-489d-8fe6-f674bd09ec0e.outcomes.js"></script>
     <script src="../dist/index.browser.js"></script>
 
     <link href="https://unpkg.com/normalize.css@^7.0.0" rel="stylesheet" />

--- a/samples/simple.html
+++ b/samples/simple.html
@@ -1,9 +1,4 @@
-<script>
-    window.autotuneConfig = {
-        appKey: "0831cd5d-5c9c-489d-8fe6-f674bd09ec0e",
-        outcomes: {}
-    };
-</script>
+<script src="//s3.us-east-2.amazonaws.com/js.autotune.xyz/0831cd5d-5c9c-489d-8fe6-f674bd09ec0e.outcomes.js"></script>
 <script src="../dist/index.browser.js"></script>
 
 <!-- Place a few options between <autotune> tags. -->

--- a/src/BrowserEnvironment.ts
+++ b/src/BrowserEnvironment.ts
@@ -82,4 +82,10 @@ export class BrowserEnvironment implements Environment {
     startHTMLExperiments(): void {
         startHTMLExperiments();
     }
+
+    autocomplete(complete: (payoff: number) => void): void {
+        for (const [delay, reward] of [[10, 0.1], [60, 0.2]]) {
+            setTimeout(() => complete(reward), delay * 1000);
+        }
+    }
 }

--- a/src/Client.test.ts
+++ b/src/Client.test.ts
@@ -73,6 +73,7 @@ class TestEnvironment implements Environment {
 
     numOutcomesRequested: number = 0;
     htmlExperimentsStarted: boolean = false;
+    autocompleteCalled: boolean = false;
     startExperimentsData: any = undefined;
     completeExperimentsData: any = undefined;
     readonly localStorage: { [key: string]: string } = {};
@@ -198,6 +199,10 @@ class TestEnvironment implements Environment {
 
     startHTMLExperiments(): void {
         this.htmlExperimentsStarted = true;
+    }
+
+    autocomplete(complete: (payoff: number) => void): void {
+        this.autocompleteCalled = true;
     }
 
     checkStartExperiments(options: string[], pick: string, pickedBest: boolean | undefined): string {

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -17,4 +17,6 @@ export interface Environment {
     setLocalStorage(key: string, value: string): void;
 
     startHTMLExperiments(): void;
+
+    autocomplete(complete: (payoff: number) => void): void;
 }


### PR DESCRIPTION
* Pays off 0.1 after 10 seconds, 0.2 after 60.
* Does not run when `autotune.initialize` is called without preloaded outcomes.